### PR TITLE
Push 'master' not 'base'

### DIFF
--- a/getting-started/installation.rst
+++ b/getting-started/installation.rst
@@ -93,4 +93,4 @@ Publishing your repo
 
     git remote rename origin playdoh
     git remote add origin git@github.com:mozilla/foobar.git
-    git push -u origin base
+    git push -u origin master


### PR DESCRIPTION
In the "Getting started with playdoh" section user is instructed to create and switch to master branch. In the section "Publishing your repo" the repository which has the user changes should be pushed, i.e. master and not base, if of course I understand the flow correctly ;)
