### PR TITLE
Added a note to recursively clone the playdoh repository before running ...

### DIFF
--- a/getting-started/vagrant.rst
+++ b/getting-started/vagrant.rst
@@ -52,6 +52,13 @@ How Do I Boot and Access My VM?
 
 ::
 
+If you don't yet have a project directory, you'll want to recursively clone the
+playdoh repository:
+
+    git clone https://github.com/mozilla/playdoh.git my_project_directory --recursive
+
+Then, enter the directory and tell vagrant to spin up a VM:
+
     cd ~/my_project_directory
     vagrant up
 


### PR DESCRIPTION
...'vagrant up' (I didn't do it recursively, so had to wait several minutes for 'vagrant up' to mysteriously crash).
