### PR TITLE
Add settings management API doc; update other pages to refer to it where appropriate.

### DIFF
--- a/getting-started/installation.rst
+++ b/getting-started/installation.rst
@@ -78,6 +78,11 @@ You can now view the dev server at http://localhost:8000/ -- hooray!
 If you start adding pieces that should go back into playdoh, you will probably
 want to patch `funfactory`_, which is the core of Playdoh.
 
+If your app's configuration requires you to add or remove apps, middleware, or
+template context processors from the default funfactory configuration, you can
+use the ``get_apps``, ``get_middleware``, and ``get_context_processors``
+functions. See the :ref:`settings management API <settings>` documentation.
+
 .. _funfactory: https://github.com/mozilla/funfactory
 .. _`MySQL`: http://www.mysql.com/
 

--- a/getting-started/upgrading.rst
+++ b/getting-started/upgrading.rst
@@ -39,32 +39,18 @@ Applying Playdoh to an existing Django app is a little different than
 
    to::
 
-        INSTALLED_APPS = list(INSTALLED_APPS) + [...]
+        INSTALLED_APPS = get_apps(append=(...))
 
    Do the same for any other lists which have been customized.
    This will ensure that you inherit the default funfactory settings.
 
-   You can remove any entries in ``INSTALLED_APPS`` from your ``settings.py``
-   if they are already in ``funfactory.settings_base.py`` by using the utility
-   function ``get_apps`` from funfactory's ``utils.py``::
-
-        from funfactory.utils import get_apps
-
-        INSTALLED_APPS = get_apps(exclude=(
-            'django.contrib.auth',
-            'django_sha2'
-        ))
-
-   Similar functions ``get_middleware`` and ``get_template_context_processors``
-   exist to help manage ``MIDDLEWARE_CLASSES`` and
-   ``TEMPLATE_CONTEXT_PROCESSORS`` respectively.
+   See the :ref:`settings management API <settings>` for information about
+   funfactory's built-in settings management functions, including ``get_apps``.
 
 #. You can remove any redundant settings in ``settings.py`` if they appear in
    ``funfactory.settings_base``.
 
 .. _`funfactory from PyPI`: http://pypi.python.org/pypi/funfactory
-
-.. _manual-upgrae:
 
 
 Mind those monkey patches
@@ -79,6 +65,8 @@ when running ``runserver`` and when running as a WSGI app.
 See the :ref:`Monkey patches <monkeypatches>` documentation for the
 lines you need to add to your root urls.py if you don't already have
 them.
+
+.. _manual-upgrade:
 
 Manual upgrade
 --------------

--- a/userguide/index.rst
+++ b/userguide/index.rst
@@ -15,3 +15,4 @@ User Guide
    logging
    template-context
    errors
+   settings

--- a/userguide/settings.rst
+++ b/userguide/settings.rst
@@ -1,0 +1,39 @@
+.. _settings:
+
+=======================
+Settings Management API
+=======================
+
+Funfactory's default settings module provides some useful helper functions that
+make managing your playdoh app's settings easier.
+
+* ``get_apps(exclude=(), append=())``
+
+    The ``get_apps`` function returns the current INSTALLED_APPS tuple, modified
+    based on the ``exclude`` and ``append`` parameters, which can be tuples or
+    lists. INSTALLED_APPS originates in funfactory's ``settings_base.py`` file,
+    containing the default suite of funfactory apps, but can be modified using
+    this function to add or remove apps as necessary for your project.
+    
+    The state of the INSTALLED_APPS tuple returned by this function persists so
+    that you can modify it as necessary for your app in ``settings/base.py``
+    and then further modify it for your local install in ``settings/local.py``.
+
+    Example::
+
+        INSTALLED_APPS = get_apps(
+            exclude=('cronjobs', 'djcelery'),
+            append=('debug_toolbar',)
+        )
+
+* ``get_middleware(exclude=(), append=())``
+
+    Similar to ``get_apps``, this function returns the current
+    MIDDLEWARE_CLASSES tuple and persists its state through the various
+    settings files.
+
+* ``get_template_context_processors(exclude=(), append=())``
+
+    Again, similar to ``get_apps`` but returns the current
+    TEMPLATE_CONTEXT_PROCESSORS tuple and persists its state through the various
+    settings files.


### PR DESCRIPTION
Documents the settings `get_` functions and adds links to the configuration and upgrading sections.
