### PR TITLE
Update libs.rst

### DIFF
--- a/userguide/libs.rst
+++ b/userguide/libs.rst
@@ -27,7 +27,7 @@ Database
 Deferred Execution (cron, message queues)
 -----------------------------------------
 
-* `django-celery <https://github.com/ask/django-celery>`_\*:
+* `django-celery <https://github.com/celery/django-celery>`_\*:
   Celery integration for Django.
 * `django-cronjobs <https://github.com/jsocol/django-cronjobs>`_\*:
   A simple cron-running management command for Django.


### PR DESCRIPTION
Updated django-celery url to point to celery/django-celery (which looks like it's being maintained) instead of the fork ask/django-celery (which hasn't been updated since 2012). It looks like funfactory uses this version as well (https://github.com/mozilla/funfactory/blob/master/funfactory/requirements/prod.txt).
